### PR TITLE
Idempotent receiver for Quakes

### DIFF
--- a/idempotent.go
+++ b/idempotent.go
@@ -1,0 +1,45 @@
+package msg
+
+import (
+	"sync"
+	"time"
+)
+
+// IdpQuake can be used to implement an idempotent receiver for Quakes.
+// Thread safe.
+type IdpQuake struct {
+	idp map[string]Quake
+	mu  sync.RWMutex
+}
+
+// Seen returns true if the Quake q has been previously
+// seen via Add().  False otherwise.
+// Quakes older than 60 minutes are evicted from i before checking for q.
+func (i *IdpQuake) Seen(q Quake) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if i.idp == nil {
+		i.idp = make(map[string]Quake)
+	}
+
+	c := time.Now().UTC().Add(time.Duration(-60 * time.Minute))
+
+	for _, e := range i.idp {
+		if e.Time.Before(c) {
+			delete(i.idp, e.PublicID)
+		}
+	}
+
+	_, b := i.idp[q.PublicID]
+
+	return b
+}
+
+// Add adds Quake.
+func (i *IdpQuake) Add(q Quake) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	i.idp[q.PublicID] = q
+}

--- a/idempotent_test.go
+++ b/idempotent_test.go
@@ -1,0 +1,42 @@
+package msg
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIdpQuake(t *testing.T) {
+	idpq := IdpQuake{}
+
+	q := Quake{
+		Time:     time.Now().UTC().Add(time.Duration(-15 * time.Minute)),
+		PublicID: "1234",
+	}
+
+	if idpq.Seen(q) != false {
+		t.Error("should not have seen quake 1234")
+	}
+
+	idpq.Add(q)
+
+	if idpq.Seen(q) != true {
+		t.Error("should have seen quake 1234")
+	}
+
+	// an old quake
+	o := Quake{
+		Time:     time.Now().UTC().Add(time.Duration(-100 * time.Minute)),
+		PublicID: "1234567",
+	}
+
+	idpq.Add(o)
+
+	if idpq.Seen(o) != false {
+		t.Error("should not have seen quake 1234567 - it's old and should have been removed.")
+	}
+
+	if idpq.Seen(q) != true {
+		t.Error("should have seen quake 1234")
+	}
+
+}


### PR DESCRIPTION
Resolves #14.

@junghao or @bpeng - who ever is least busy please could you review this?

The idea is for quake alerting we only want to alert on the first quake message that passes the criteria.

Thanks,
Geoff
