### PR TITLE
add DepthType.  Resolves #11.

### DIFF
--- a/quake.go
+++ b/quake.go
@@ -24,6 +24,7 @@ type Quake struct {
 	Latitude              float64
 	Longitude             float64
 	Depth                 float64
+	DepthType             string
 	MethodID              string
 	EarthModelID          string
 	EvaluationMode        string

--- a/seiscompml07.go
+++ b/seiscompml07.go
@@ -42,6 +42,7 @@ type origin struct {
 	Latitude         value        `xml:"latitude"`
 	Longitude        value        `xml:"longitude"`
 	Depth            value        `xml:"depth"`
+	DepthType        string       `xml:"depthType"`
 	Quality          quality      `xml:"quality"`
 	MethodID         string       `xml:"methodID"`
 	EarthModelID     string       `xml:"earthModelID"`
@@ -203,6 +204,7 @@ func (s *sc3ml07) quake() (q Quake) {
 	q.EarthModelID = s.EventParameters.Event.PreferredOrigin.EarthModelID
 	q.EvaluationMode = s.EventParameters.Event.PreferredOrigin.EvaluationMode
 	q.EvaluationStatus = s.EventParameters.Event.PreferredOrigin.EvaluationStatus
+	q.DepthType = s.EventParameters.Event.PreferredOrigin.DepthType
 	q.MagnitudeType = s.EventParameters.Event.PreferredMagnitude.Type
 
 	mt, err := s.quakeModTime()


### PR DESCRIPTION
This should add the only other field we need to be able to use this message for the wfs client as well.

I've never actually seen a SC3ML file with this set.  Do you happen to have one from the CUSP offload with this set so I can add a test for this?  If not that is ok (Kevin told me this is the correct field).

Merge when you're happy.