### PR TITLE
Quake alerting v2

### DIFF
--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -1,0 +1,101 @@
+package pagerduty
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/GeoNet/cfg"
+	"log"
+	"net/http"
+	"time"
+)
+
+const api = "https://events.pagerduty.com/generic/2010-04-15/create_event.json"
+
+var retry = time.Duration(30) * time.Second
+
+type trigger struct {
+	ServiceKey  string `json:"service_key"`
+	EventType   string `json:"event_type"`
+	Description string `json:"description"`
+	IncidentKey string `json:"incident_key"`
+}
+
+type Client struct {
+	apiToken string
+	h        *http.Client
+}
+
+func Init(c *cfg.PagerDuty) *Client {
+	a := &Client{
+		apiToken: c.ApiToken,
+		h:        &http.Client{},
+	}
+
+	return a
+}
+
+// Trigger an event via the PagerDuty api.  IncidentKey is used for de-duping.
+// https://developer.pagerduty.com/documentation/integration/events/trigger
+// If an error is encountered then creating the incident is attempted retries more times with
+// a pause of 30s between each attempt.  retries can be 0 to attempt publishing only once.
+// Anything other than a 200 response from the API is treated as an error.
+func (a *Client) Trigger(c *cfg.PagerDuty, Description, IncidentKey string, retries int) (err error) {
+	t := trigger{
+		ServiceKey:  c.ServiceKey,
+		Description: Description,
+		IncidentKey: IncidentKey,
+		EventType:   "trigger",
+	}
+
+	b, err := json.Marshal(t)
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequest("POST", api, bytes.NewBuffer(b))
+	if err != nil {
+		return
+	}
+
+	req.Header.Add("Authorization", "Token token="+a.apiToken)
+	req.Header.Add("Content-Type", "application/json")
+
+	cnt := 0
+	var res *http.Response
+	for {
+		res, err = a.h.Do(req)
+		if err == nil {
+			defer res.Body.Close()
+
+			// Return for success or unrecoverable errors.  Other errors (including network) we can back
+			// off and try again for.
+			// https://developer.pagerduty.com/documentation/rest/errors
+			switch res.StatusCode {
+			case 200:
+				return // success, we're out
+			case 400:
+				err = fmt.Errorf("400 from PagerDuty: Caller provided invalid arguments.")
+				return
+			case 401:
+				err = fmt.Errorf("401 forbidden  from PagerDuty")
+				return
+			case 404:
+				err = fmt.Errorf("404 not found from PagerDuty")
+				return
+			}
+		}
+		if cnt >= retries {
+			if err == nil {
+				err = fmt.Errorf("ran out of retries sending to PagerDuty.")
+			}
+			break
+		}
+		cnt++
+
+		log.Println("WARN error sending to PagerDuty.  Sleeping and trying again")
+		time.Sleep(retry)
+	}
+
+	return
+}

--- a/quake.go
+++ b/quake.go
@@ -203,3 +203,24 @@ func (q *Quake) AlertQuality() bool {
 
 	return true
 }
+
+// Publish returns true if the quake is suitable for publishing.
+// site is either 'primary' or 'backup'.
+func (q *Quake) Publish(site string) bool {
+	if q.err != nil {
+		return false
+	}
+
+	p := true
+	switch site {
+	case "primary":
+		if q.Status() == "automatic" && !(q.Depth >= 0.1 && q.AzimuthalGap <= 320.0 && q.MinimumDistance <= 2.5) {
+			p = false
+		}
+	case "backup":
+		if q.Status() == "automatic" {
+			p = false
+		}
+	}
+	return p
+}

--- a/quake_test.go
+++ b/quake_test.go
@@ -197,9 +197,59 @@ func TestAlertQuality(t *testing.T) {
 
 }
 
+func TestPublish(t *testing.T) {
+	q := Quake{}
+
+	eq(t, false, q.Publish("primary"))
+	eq(t, false, q.Publish("backup"))
+
+	q.Type = ""
+	q.EvaluationStatus = "automatic"
+
+	eq(t, false, q.Publish("primary"))
+	eq(t, false, q.Publish("backup"))
+
+	q.EvaluationStatus = "confirmed"
+
+	eq(t, true, q.Publish("primary"))
+	eq(t, true, q.Publish("backup"))
+
+	q.EvaluationStatus = "automatic"
+	q.Depth = 0.01
+	q.AzimuthalGap = 321.0
+	q.MinimumDistance = 3.0
+
+	eq(t, false, q.Publish("primary"))
+	eq(t, false, q.Publish("backup"))
+
+	q.EvaluationStatus = "automatic"
+	q.Depth = 0.2
+	q.AzimuthalGap = 319.0
+	q.MinimumDistance = 2.4
+
+	eq(t, true, q.Publish("primary"))
+	eq(t, false, q.Publish("backup"))
+
+	q.EvaluationStatus = "confirmed"
+
+	eq(t, true, q.Publish("primary"))
+	eq(t, true, q.Publish("backup"))
+
+	q.SetErr(fmt.Errorf("errored quake"))
+
+	eq(t, false, q.Publish("primary"))
+	eq(t, false, q.Publish("backup"))
+}
+
 func delta(t *testing.T, expected, actual, delta float64) {
 	if math.Abs(expected-actual) > delta {
 		t.Errorf("%s expected %f got %f diff = %f", loc(), expected, actual, math.Abs(expected-actual))
+	}
+}
+
+func eq(t *testing.T, expected, actual interface{}) {
+	if expected != actual {
+		t.Error("%s not equal", loc())
 	}
 }
 

--- a/sns/sns.go
+++ b/sns/sns.go
@@ -53,7 +53,9 @@ func (s *SNS) Publish(m msg.Raw, retries int) (err error) {
 		}
 		c++
 
+		log.Println("WARN " + err.Error())
 		log.Println("WARN error sending to SNS.  Sleeping and trying again")
+
 		time.Sleep(retry)
 	}
 	return err


### PR DESCRIPTION
Hi Howard,

@kfenaugh reviewed the alert rules for functional correctness in https://github.com/GeoNet/msg/pull/24 and I have made the changes he requested and rebased this down into one commit (e9cc7ee).

The also adds a function for sending to PagerDuty with retries.

Please could you code review this PR?  Merge when you're happy.

snap-ci is still failing.  There is a bug in snap that I will report to them later.

Thanks,
Geoff

